### PR TITLE
update deploy to use clean flag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
             - name: Inspect
               run: ls -l && ls -l content
             - name: Build site
-              run: syrinx .
+              run: syrinx . -c
             - name: Inspect files
               run: ls -l dist/
             - name: Set up QEMU


### PR DESCRIPTION
Use clean flag as part of build to remove people/replications/publications etc that are no longer part of the project but still showing up.

May also be worth removing the generated md files from the repo so they have to be generated anew every time.