### PR TITLE
update production workflow to use clean flag

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Inspect
               run: ls -l && ls -l content
             - name: Build site
-              run: syrinx .
+              run: syrinx . -c
             - name: Inspect files
               run: ls -l dist/
             - name: Set up QEMU


### PR DESCRIPTION
Duplicates still showing on production version of EEGManyLabs page, need to use `-c` flag when building it.